### PR TITLE
Add platform color accents to article cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/scripts/gen_tiles.js
+++ b/scripts/gen_tiles.js
@@ -174,7 +174,7 @@ async function generateArticleTiles() {
     <div class="container">
       <h2>Articles</h2>
       <div class="articles-grid">
-        <div class="card">
+        <div class="card article-card--medium">
           <div class="card__header">
             <img src="assets/icons/new_medium_logo.svg" alt="Medium" class="platform-logo">
             <h4 class="card__title">Medium</h4>
@@ -190,7 +190,7 @@ async function generateArticleTiles() {
             `).join('')}
           </div>
         </div>
-        <div class="card">
+        <div class="card article-card--substack">
           <div class="card__header">
             <img src="assets/icons/substack.svg" alt="Substack" class="platform-logo">
             <h4 class="card__title">Substack</h4>

--- a/styles.css
+++ b/styles.css
@@ -952,6 +952,14 @@ a.card-link {
   margin-bottom: var(--space-3);
 }
 
+.article-card--medium {
+  border-top: 3px solid #000;
+}
+
+.article-card--substack {
+  border-top: 3px solid #FF6719;
+}
+
 
 /* ===========================
    CONTACT SECTION


### PR DESCRIPTION
## Summary
- Adds a black (`#000`) top border to the Medium article card to match Medium's brand
- Adds an orange (`#FF6719`) top border to the Substack article card to match Substack's brand
- Makes each platform instantly distinguishable at a glance without changing card layout

## Test plan
- [ ] Visit the Articles section and confirm Medium card has a black top accent
- [ ] Confirm Substack card has an orange top accent
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)