### PR TITLE
Show experience descriptions in timeline cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/scripts/gen_tiles.js
+++ b/scripts/gen_tiles.js
@@ -122,6 +122,7 @@ async function generateExperienceTiles() {
               <h4 class="card__title">${exp.position}</h4>
               <p class="card__subtitle">${exp.company}</p>
               <p class="timeline-date">${exp.date}</p>
+              <p class="card__text timeline-description">${exp.description}</p>
             </div>
           `;
           return `

--- a/styles.css
+++ b/styles.css
@@ -877,6 +877,10 @@ a.card-link {
   margin: var(--space-2) 0 0;
 }
 
+.timeline-description {
+  margin-top: var(--space-3);
+}
+
 @media (max-width: 768px) {
   .timeline::before {
     left: 19px;


### PR DESCRIPTION
## Summary
- Renders the `description` field from `experience.json` inside each timeline card (it was previously unused/hidden)
- Adds `margin-top: var(--space-3)` via `.timeline-description` class for breathing room below the date line
- Makes each role's narrative visible, improving the experience section's storytelling

## Test plan
- [ ] Visit the Experience section and confirm each role now shows its description text
- [ ] Verify spacing between date and description looks clean on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)