### PR TITLE
Add speaking section with ticket-style card design

### DIFF
--- a/data/speaking.json
+++ b/data/speaking.json
@@ -1,0 +1,16 @@
+[
+  {
+    "event": "Snowflake Summit 2026",
+    "eventLogo": "assets/icons/snowflake.svg",
+    "title": "Self-Healing Semantic Layers with Snowflake Cortex AI: How Sigma Built J.A.K.E.",
+    "abstract": "How Sigma built J.A.K.E., a production Cortex AI agent embedded in Slack and Sigma that self-heals semantic layers by automatically generating Snowflake semantic views from dbt metadata, debugging query failures in real time, and patching definitions to create a continuous learning loop.",
+    "date": "June 2026",
+    "location": "San Francisco, CA",
+    "upcoming": true,
+    "links": {
+      "eventPage": "https://reg.snowflake.com/flow/snowflake/summit26/sessions/page/catalog/session/1767825886058001MnA1",
+      "slides": null,
+      "recording": null
+    }
+  }
+]

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
           <li><a href="#experience">Experience</a></li>
           <li><a href="#education">Education</a></li>
           <li><a href="#projects">Projects</a></li>
+          <li><a href="#speaking">Speaking</a></li>
           <li><a href="#papers">Papers</a></li>
           <li><a href="#articles">Articles</a></li>
           <li><a href="#contact">Social</a></li>
@@ -152,6 +153,9 @@
 
     <!-- PROJECTS -->
     <section id="projects"></section>
+
+    <!-- SPEAKING -->
+    <section id="speaking"></section>
 
     <!-- PAPERS -->
     <section id="papers"></section>

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ window.onload = function () {
   generatePaperTiles();
   generateEducationTiles();
   generateExperienceTiles();
+  generateSpeakingTiles();
   generateArticleTiles();
   generateContactTiles();
 };

--- a/scripts/gen_tiles.js
+++ b/scripts/gen_tiles.js
@@ -169,6 +169,43 @@ async function generateContactTiles() {
 }
 
 
+async function generateSpeakingTiles() {
+  const response = await fetch('data/speaking.json');
+  const engagements = await response.json();
+  const section = document.querySelector('#speaking');
+
+  const ticketsHTML = engagements.map(e => {
+    const links = [
+      e.links.eventPage ? `<a href="${e.links.eventPage}" target="_blank" class="btn-ghost btn-sm">Event Page</a>` : '',
+      e.links.slides    ? `<a href="${e.links.slides}"    target="_blank" class="btn-ghost btn-sm">Slides</a>`     : '',
+      e.links.recording ? `<a href="${e.links.recording}" target="_blank" class="btn-ghost btn-sm">Recording</a>`  : '',
+    ].filter(Boolean).join('');
+
+    return `
+      <div class="ticket">
+        ${e.upcoming ? '<span class="ticket__badge">Coming Soon</span>' : ''}
+        <div class="ticket__stub">
+          <img src="${e.eventLogo}" alt="${e.event}" class="ticket__stub-logo">
+          <div class="ticket__stub-event">${e.event}</div>
+          <div class="ticket__stub-meta">${e.date}<br>${e.location}</div>
+        </div>
+        <div class="ticket__body">
+          <div class="ticket__speaker-label">Speaker</div>
+          <div class="ticket__title">${e.title}</div>
+          <div class="ticket__abstract">${e.abstract}</div>
+          <div class="ticket__links">${links}</div>
+        </div>
+      </div>`;
+  }).join('');
+
+  section.innerHTML = `
+    <div class="container">
+      <h2>Speaking</h2>
+      <div class="speaking-list">${ticketsHTML}</div>
+    </div>`;
+}
+
+
 async function generateArticleTiles() {
   const response = await fetch('data/articles.json');
   const articles = await response.json();

--- a/styles.css
+++ b/styles.css
@@ -984,6 +984,133 @@ a.card-link {
 
 
 /* ===========================
+   SPEAKING SECTION
+   =========================== */
+
+.speaking-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.ticket {
+  display: flex;
+  border: 2px dashed var(--card-border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card-bg);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: rotate(-0.4deg);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+}
+
+.ticket:hover {
+  transform: rotate(0deg) translateY(-3px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
+}
+
+.ticket__stub {
+  min-width: 180px;
+  padding: var(--space-4);
+  border-right: 2px dashed var(--card-border);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.ticket__stub-logo {
+  height: 36px;
+  width: auto;
+  object-fit: contain;
+}
+
+.ticket__stub-event {
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+
+.ticket__stub-meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-accent);
+  line-height: 1.6;
+}
+
+.ticket__body {
+  flex: 1;
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ticket__speaker-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.ticket__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.ticket__abstract {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-family: var(--font-accent);
+  line-height: 1.6;
+}
+
+.ticket__links {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+
+.ticket__badge {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  background: var(--accent);
+  color: white;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 999px;
+}
+
+.btn-sm {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.8rem;
+}
+
+@media (max-width: 600px) {
+  .ticket {
+    flex-direction: column;
+    transform: none;
+  }
+
+  .ticket__stub {
+    border-right: none;
+    border-bottom: 2px dashed var(--card-border);
+    min-width: unset;
+  }
+}
+
+
+/* ===========================
    CONTACT SECTION
    =========================== */
 


### PR DESCRIPTION
## Summary

- Adds a new Speaking section to the portfolio, positioned above Papers and Articles
- Each engagement renders as a conference ticket: dashed perforated border, left stub (event logo, name, date/location) and right body (talk title, abstract, CTA buttons)
- Upcoming talks display a \"Coming Soon\" badge
- First entry: Snowflake Summit 2026 session on self-healing semantic layers with J.A.K.E.
- Section data is driven by `data/speaking.json` for easy future updates

## Test plan

- [ ] Navigate to site and confirm \"Speaking\" appears in the nav above Papers
- [ ] Click nav link and verify page scrolls to the section
- [ ] Confirm ticket renders with dashed border, stub on left, body on right
- [ ] Confirm \"Coming Soon\" badge is visible
- [ ] Confirm \"Event Page\" button links to the Snowflake Summit session page
- [ ] Hover the ticket and verify it un-rotates and lifts slightly
- [ ] Resize to mobile and confirm ticket stacks vertically with horizontal dashed divider
- [ ] Toggle dark mode and confirm ticket styling holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)