### PR TITLE
SEO audit: structured data, meta tags, article schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Portfolio site for Matthew Senick. Deployed via GitHub Pages at `matthewsenick.c
 │   ├── education.json
 │   ├── projects.json
 │   ├── papers.json
-│   ├── articles.json   # Nested: { "medium": [...], "substack": [...] }
+│   ├── articles.json   # Nested: { "medium": [...], "substack": [...], "sigma": [...] }
 │   ├── speaking.json   # Flat array of speaking engagements
 │   └── contact.json
 │
@@ -212,6 +212,28 @@ python3 -m http.server
 No npm, no bundler, no compilation. Edit files and refresh.
 
 **Deployment**: push to `main` — GitHub Pages deploys automatically via the `CNAME` config.
+
+---
+
+## SEO Architecture
+
+### Static meta tags (index.html `<head>`)
+- `og:image` uses the profile photo at `assets/other/matthew-senick.png` (800×800)
+- `og:image:width/height/alt` and `og:site_name` are set alongside the main OG block
+- `twitter:card` is `summary` (not `summary_large_image`) because the profile image is square
+- `meta name="robots"` and `meta name="theme-color"` (#4CAF50) are explicit
+
+### JSON-LD structured data (index.html)
+The `<script type="application/ld+json">` in `<head>` contains an `@graph` with three schemas:
+- **Person** (`@id: #person`) — includes `worksFor` (Sigma Computing), `alumniOf`, `knowsAbout` (skills list), `hasOccupation`, and `sameAs` social links
+- **WebSite** (`@id: #website`) — site identity for Google; linked to Person via `author`
+- **Event** — one entry per speaking engagement; add a new object here when a new talk is added to `speaking.json`
+
+### Dynamic BlogPosting schema (index.js)
+`injectArticleSchema()` runs at page load, fetches `data/articles.json`, and injects a second `<script type="application/ld+json">` into `<head>` with a `BlogPosting` per visible article (all three tabs: medium, substack, sigma). Each BlogPosting references `{ "@id": "https://matthewsenick.com/#person" }` as its author. This function does not need updating when articles are added — it reads from the JSON automatically.
+
+### When adding a new speaking engagement
+Add the entry to `speaking.json` **and** add a corresponding `Event` object to the `@graph` JSON-LD block in `index.html`.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -23,34 +23,96 @@
   <meta property="og:description" content="Portfolio of Matthew Senick (Matt Senick) — Senior Analytics Engineer. Data, design, and engineering.">
   <meta property="og:url" content="https://matthewsenick.com">
   <meta property="og:image" content="https://matthewsenick.com/assets/other/matthew-senick.png">
+  <meta property="og:image:width" content="800">
+  <meta property="og:image:height" content="800">
+  <meta property="og:image:alt" content="Matthew Senick — Senior Analytics Engineer">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Matthew Senick">
 
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Matthew Senick — Senior Analytics Engineer">
   <meta name="twitter:description" content="Portfolio of Matthew Senick (Matt Senick) — Senior Analytics Engineer. Data, design, and engineering.">
   <meta name="twitter:image" content="https://matthewsenick.com/assets/other/matthew-senick.png">
 
-  <!-- Structured data: Person schema for Google image search association -->
+  <meta name="robots" content="index, follow">
+  <meta name="theme-color" content="#4CAF50">
+
+  <!-- Structured data: Person, WebSite, and Event schemas -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Matthew Senick",
-    "alternateName": "Matt Senick",
-    "url": "https://matthewsenick.com",
-    "image": "https://matthewsenick.com/assets/other/matthew-senick.png",
-    "jobTitle": "Senior Analytics Engineer",
-    "sameAs": [
-      "https://www.linkedin.com/in/matthew-senick/",
-      "https://github.com/Matts52",
-      "https://medium.com/@senick.matthew",
-      "https://substack.com/@matthewsenick"
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": "https://matthewsenick.com/#person",
+        "name": "Matthew Senick",
+        "alternateName": "Matt Senick",
+        "url": "https://matthewsenick.com",
+        "image": {
+          "@type": "ImageObject",
+          "url": "https://matthewsenick.com/assets/other/matthew-senick.png",
+          "width": 800,
+          "height": 800
+        },
+        "jobTitle": "Senior Analytics Engineer",
+        "description": "Senior Analytics Engineer specializing in dbt, Snowflake, and analytics infrastructure. Author of 18+ articles on analytics engineering.",
+        "worksFor": {
+          "@type": "Organization",
+          "name": "Sigma Computing",
+          "url": "https://www.sigmacomputing.com"
+        },
+        "alumniOf": [
+          { "@type": "EducationalOrganization", "name": "University of Saskatchewan" },
+          { "@type": "EducationalOrganization", "name": "University of Toronto" }
+        ],
+        "knowsAbout": [
+          "Analytics Engineering", "dbt", "Snowflake", "SQL", "Python",
+          "R", "Data Engineering", "Machine Learning", "Business Intelligence",
+          "Sigma Computing", "PostgreSQL", "A/B Testing"
+        ],
+        "hasOccupation": {
+          "@type": "Occupation",
+          "name": "Analytics Engineer",
+          "occupationLocation": { "@type": "Country", "name": "Canada" }
+        },
+        "sameAs": [
+          "https://www.linkedin.com/in/matthew-senick/",
+          "https://github.com/Matts52",
+          "https://medium.com/@senick.matthew",
+          "https://substack.com/@matthewsenick"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://matthewsenick.com/#website",
+        "name": "Matthew Senick",
+        "url": "https://matthewsenick.com",
+        "description": "Portfolio of Matthew Senick (Matt Senick) — Senior Analytics Engineer",
+        "author": { "@id": "https://matthewsenick.com/#person" }
+      },
+      {
+        "@type": "Event",
+        "name": "Self-Healing Semantic Layers with Snowflake Cortex AI: How Sigma Built J.A.K.E.",
+        "startDate": "2026-06",
+        "location": {
+          "@type": "Place",
+          "name": "Snowflake Summit 2026",
+          "address": { "@type": "PostalAddress", "addressLocality": "San Francisco", "addressRegion": "CA" }
+        },
+        "description": "How Sigma built J.A.K.E., a production Cortex AI agent embedded in Slack and Sigma that self-heals semantic layers by automatically generating Snowflake semantic views from dbt metadata, debugging query failures in real time, and patching definitions to create a continuous learning loop.",
+        "organizer": { "@type": "Organization", "name": "Snowflake" },
+        "performer": { "@id": "https://matthewsenick.com/#person" },
+        "eventStatus": "https://schema.org/EventScheduled",
+        "url": "https://reg.snowflake.com/flow/snowflake/summit26/sessions/page/catalog/session/1767825886058001MnA1"
+      }
     ]
   }
   </script>
 
   <title>Matthew Senick — Senior Analytics Engineer</title>
+
+  <link rel="preload" as="image" href="assets/other/matthew-senick.png">
 
   <!-- Google Fonts: Space Grotesk + Spectral -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.js
+++ b/index.js
@@ -9,7 +9,29 @@ window.onload = function () {
   generateSpeakingTiles();
   generateArticleTiles();
   generateContactTiles();
+
+  injectArticleSchema();
 };
+
+async function injectArticleSchema() {
+  const data = await fetch('data/articles.json').then(r => r.json());
+  const allArticles = [
+    ...data.medium.filter(a => a.show),
+    ...data.substack.filter(a => a.show),
+    ...(data.sigma || []).filter(a => a.show)
+  ];
+  const schemas = allArticles.map(a => ({
+    "@type": "BlogPosting",
+    "headline": a.title,
+    "url": a.link,
+    "datePublished": a.published_date,
+    "author": { "@id": "https://matthewsenick.com/#person" }
+  }));
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.text = JSON.stringify({ "@context": "https://schema.org", "@graph": schemas });
+  document.head.appendChild(script);
+}
 
 
 /*** Section fade-in with IntersectionObserver ***/


### PR DESCRIPTION
## Summary

- Expands the JSON-LD structured data in `index.html` from a basic Person schema into a full `@graph` containing enhanced Person (with `worksFor`, `alumniOf`, `knowsAbout`, `hasOccupation`), WebSite, and Event schemas for Google Knowledge Panel and rich result eligibility
- Adds missing OG meta tags (`og:image:width/height/alt`, `og:site_name`), switches `twitter:card` to `summary` to match the square 800×800 profile photo, and adds explicit `robots` and `theme-color` meta tags
- Adds `injectArticleSchema()` in `index.js` that dynamically injects `BlogPosting` JSON-LD for all 20 visible articles (Medium, Substack, Sigma tabs), associating Matt's bylines with his site in Google's knowledge graph
- Adds a preload hint for the profile photo to improve LCP, and documents the full SEO architecture in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)