### PR TITLE
Add Sigma Computing webinar to speaking engagements

### DIFF
--- a/data/speaking.json
+++ b/data/speaking.json
@@ -1,5 +1,19 @@
 [
   {
+    "event": "Sigma Computing Webinar",
+    "eventLogo": "assets/companies/sigma-computing.svg",
+    "title": "Self-Healing Semantic Layers with Snowflake Cortex AI",
+    "abstract": "An inside look at J.A.K.E. (Just Another Knowledge Engine), a production-grade Cortex AI agent embedded in Slack and Sigma that self-heals semantic layers — automatically generating Snowflake semantic views from dbt metadata, capturing query failures, identifying root causes, and patching definitions to create a continuous AgenticOps learning loop.",
+    "date": "July 22, 2026",
+    "location": "Virtual",
+    "upcoming": true,
+    "links": {
+      "eventPage": "https://events.sigmacomputing.com/semanticlayerswithsnowflakecortexai",
+      "slides": null,
+      "recording": null
+    }
+  },
+  {
     "event": "Snowflake Summit 2026",
     "eventLogo": "assets/icons/snowflake.svg",
     "title": "Self-Healing Semantic Layers with Snowflake Cortex AI: How Sigma Built J.A.K.E.",

--- a/index.html
+++ b/index.html
@@ -105,6 +105,21 @@
         "performer": { "@id": "https://matthewsenick.com/#person" },
         "eventStatus": "https://schema.org/EventScheduled",
         "url": "https://reg.snowflake.com/flow/snowflake/summit26/sessions/page/catalog/session/1767825886058001MnA1"
+      },
+      {
+        "@type": "Event",
+        "name": "Self-Healing Semantic Layers with Snowflake Cortex AI",
+        "startDate": "2026-07-22",
+        "location": {
+          "@type": "VirtualLocation",
+          "url": "https://events.sigmacomputing.com/semanticlayerswithsnowflakecortexai"
+        },
+        "description": "An inside look at J.A.K.E. (Just Another Knowledge Engine), a production-grade Cortex AI agent powered by Snowflake Cortex that self-heals semantic layers by automatically generating semantic views from dbt metadata, capturing query failures, and patching definitions through a governed remediation workflow.",
+        "organizer": { "@type": "Organization", "name": "Sigma Computing" },
+        "performer": { "@id": "https://matthewsenick.com/#person" },
+        "eventStatus": "https://schema.org/EventScheduled",
+        "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+        "url": "https://events.sigmacomputing.com/semanticlayerswithsnowflakecortexai"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Adds the July 22, 2026 virtual Sigma Computing webinar "Self-Healing Semantic Layers with Snowflake Cortex AI" to `data/speaking.json` with an upcoming badge and event page link
- Adds the corresponding `Event` JSON-LD schema (with `VirtualLocation` and `OnlineEventAttendanceMode`) to the `@graph` in `index.html` for SEO

🤖 Generated with [Claude Code](https://claude.com/claude-code)